### PR TITLE
Use correct magic const for location

### DIFF
--- a/src/IncludeInterceptor.php
+++ b/src/IncludeInterceptor.php
@@ -42,7 +42,7 @@ use RuntimeException;
 
 final class IncludeInterceptor
 {
-    public const LOCATION = __DIR__;
+    public const LOCATION = __FILE__;
     private const STREAM_OPEN_FOR_INCLUDE = 0x00000080;
 
     /**


### PR DESCRIPTION
Using __DIR__ for an include isn't a great idea, we want to have the file.