### PR TITLE
Use PCOV for coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ jobs:
   fast_finish: true
   allow_failures:
     - php: nightly
-    - php: 7.4
   include:
     - stage: analyze
       php: 7.3
       install:
-        - pecl install ast
         - phpenv config-rm xdebug.ini
+        - pecl install ast
+        - pecl install pcov
         - composer install --prefer-dist
       script:
         - make ci-analyze --keep-going
@@ -32,6 +32,7 @@ cache:
 
 install:
   - phpenv config-rm xdebug.ini || true
+  - pecl install pcov
   - composer remove --no-update --dev
       phan/phan phpstan/phpstan vimeo/psalm
       infection/infection friendsofphp/php-cs-fixer

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Use any most recent PHP version
 PHP=$(shell which php)
-PHPDBG=phpdbg -qrr
+PHPDBG=php
 
 # Default parallelism
 JOBS=$(shell nproc)


### PR DESCRIPTION
Closes #6

The issue itself is related to PHPDBG incompatibilities with PHPUnit, so the best solution right now seems to be using PCOV for coverage collection. And that's what we're doing here.
