### PR TITLE
Register shutdown function and throw exception if the file was not intercepted

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.11.6@7fc1f50f54bd6b174b1c43a37c1b0b151915d55c">
+  <file src="src/IncludeInterceptor.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;fp</code>
+    </InvalidPropertyAssignmentValue>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/tests/IncludeInterceptorTest.php
+++ b/tests/IncludeInterceptorTest.php
@@ -36,11 +36,13 @@ declare(strict_types=1);
 namespace Infection\Tests\StreamWrapper;
 
 use function count;
+use Exception;
 use Infection\StreamWrapper\IncludeInterceptor;
 use InvalidArgumentException;
 use const PHP_SAPI;
 use PHPUnit\Framework\Error\Warning;
 use PHPUnit\Framework\TestCase;
+use function register_shutdown_function;
 use RuntimeException;
 
 /**
@@ -118,7 +120,7 @@ final class IncludeInterceptorTest extends TestCase
         // Sanity check
         $this->assertStringContainsString('1', $before);
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         $after = file_get_contents(self::$files[1]);
@@ -133,7 +135,7 @@ final class IncludeInterceptorTest extends TestCase
         $before = include self::$files[1];
         $this->assertSame(1, $before);
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         $after = include self::$files[1];
@@ -151,7 +153,7 @@ final class IncludeInterceptorTest extends TestCase
         $before = include self::$files[3];
         $this->assertSame(3, $before);
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         $after = include self::$files[3];
@@ -166,7 +168,7 @@ final class IncludeInterceptorTest extends TestCase
         if (PHP_SAPI === 'phpdbg') {
             $this->markTestSkipped('Running this test on PHPDBG has issues with FD_SETSIZE. Consider removing this if that issue has been fixed.');
         }
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         /*
@@ -206,7 +208,7 @@ final class IncludeInterceptorTest extends TestCase
 
     public function test_passthrough_dir_methods_pass(): void
     {
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         /*
@@ -239,7 +241,7 @@ final class IncludeInterceptorTest extends TestCase
     {
         $expected = include self::$files[2];
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         try {
@@ -259,7 +261,7 @@ final class IncludeInterceptorTest extends TestCase
     {
         $expected = include self::$files[2];
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         try {
@@ -279,7 +281,7 @@ final class IncludeInterceptorTest extends TestCase
     {
         $expected = include self::$files[2];
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         try {
@@ -299,7 +301,7 @@ final class IncludeInterceptorTest extends TestCase
     {
         $expected = include self::$files[2];
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         try {
@@ -319,7 +321,7 @@ final class IncludeInterceptorTest extends TestCase
     {
         $expected = include self::$files[2];
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         try {
@@ -339,7 +341,7 @@ final class IncludeInterceptorTest extends TestCase
     {
         $expected = include self::$files[2];
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         try {
@@ -363,7 +365,7 @@ final class IncludeInterceptorTest extends TestCase
     {
         $expected = include self::$files[2];
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         try {
@@ -383,7 +385,7 @@ final class IncludeInterceptorTest extends TestCase
     {
         $expected = include self::$files[2];
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         try {
@@ -403,7 +405,7 @@ final class IncludeInterceptorTest extends TestCase
     {
         $expected = include self::$files[2];
 
-        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $this->getShutdownFunction());
         IncludeInterceptor::enable();
 
         try {
@@ -417,5 +419,30 @@ final class IncludeInterceptorTest extends TestCase
         }
 
         $this->fail('Badly set up test, exception was not thrown');
+    }
+
+    public function test_it_throws_an_exception_if_the_file_was_not_intercepted_in_the_current_process(): void
+    {
+        $value = 0;
+
+        $shutdownHandler = static function () use (&$value): void {
+            $value = 1;
+        };
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2], $shutdownHandler);
+        IncludeInterceptor::enable();
+
+        register_shutdown_function(static function () use (&$value): void {
+            if ($value !== 1) {
+                throw new Exception('IncludeInterceptor\'s shutdown function was not executed.');
+            }
+        });
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function getShutdownFunction(): callable
+    {
+        return static function (): void {};
     }
 }


### PR DESCRIPTION
Register shutdown function and throw exception if the file was not intercepted in the current process by Infection's stream wrapper

see https://github.com/infection/infection/issues/1275

When the project uses https://github.com/dg/bypass-finals, this lib unregisters Infection's stream wrapper and registers its own. It leads to Mutant (mutated file) not being used instead of original one. 

Thus, all mutants are escaped.

With this update, Infection's user will see an error in the Infection's log with a clear message:

Before:

```
.: killed, M: escaped, U: uncovered, E: fatal error, T: timed out

.....                                                (5 / 5)
```

After:

```
Processing source code files: 2/2
.: killed, M: escaped, U: uncovered, E: fatal error, T: timed out

EEEEE                                                (5 / 5)
```

And part of the log file:

```
3) /infection/tests/e2e/Stream_Wrapper_Execution/src/FinalClass.php:11    [M] OneZeroInteger

--- Original
+++ New
@@ @@
 {
     public function get() : int
     {
-        return 1;
+        return 0;
     }
 }

  PHPUnit 8.5.7 by Sebastian Bergmann and contributors.

  ..                                                                  2 / 2 (100%)

  Time: 53 ms, Memory: 6.00 MB

  OK (2 tests, 3 assertions)

  Fatal error: Uncaught LogicException: Infection's IncludeInterceptor was not executed. Make sure you don't use any `file://` Stream Wrappers (like dg/bypass-finals) in /infection/include-interceptor/src/IncludeInterceptor.php:90
  Stack trace:
  #0 [internal function]: Infection\StreamWrapper\IncludeInterceptor::Infection\StreamWrapper\{closure}()
  #1 {main}
    thrown in /infection/include-interceptor/src/IncludeInterceptor.php on line 90
```