### PR TITLE
Respect symlinks in url_stat

### DIFF
--- a/src/IncludeInterceptor.php
+++ b/src/IncludeInterceptor.php
@@ -374,12 +374,20 @@ final class IncludeInterceptor
         return $return;
     }
 
-    public function url_stat($path)
+    public function url_stat($path, $flags)
     {
         self::disable();
 
         try {
-            return is_readable($path) ? stat($path) : false;
+            if (is_readable($path) === false) {
+                return false;
+            }
+
+            if ($flags & STREAM_URL_STAT_LINK) {
+                return lstat($path);
+            }
+
+            return stat($path);
         } finally {
             self::enable();
         }

--- a/tests/IncludeInterceptorTest.php
+++ b/tests/IncludeInterceptorTest.php
@@ -418,4 +418,19 @@ final class IncludeInterceptorTest extends TestCase
 
         $this->fail('Badly set up test, exception was not thrown');
     }
+
+    public function test_it_respects_symlinks_in_url_stat(): void
+    {
+        $expected = include self::$files[2];
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        $symlink = sys_get_temp_dir() . '/symlink-intercept';
+        self::$files[] = $symlink;
+
+        symlink(self::$files[2], $symlink);
+
+        $this->assertTrue(is_link($symlink));
+    }
 }


### PR DESCRIPTION
url_stat is called with an additional $flags argument by PHP.
This includes an flag whether info about sylimk or symlink target should
be returned.

Prior to this change, stat was used all the time, delivering results for
the target of symlinks.
Respecting the flag, lstat is used to return info about the symlink
instead, when requested.

This will properly return infos for is_link() calls.