### PR TITLE
Fix Psalm warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
         "infection/infection": "^0.15.0",
-        "phan/phan": "^2.4",
+        "phan/phan": "^2.4 || ^3",
         "php-coveralls/php-coveralls": "^2.2",
         "phpstan/phpstan": "^0.12.8",
         "phpunit/phpunit": "^8.5",

--- a/src/IncludeInterceptor.php
+++ b/src/IncludeInterceptor.php
@@ -221,6 +221,9 @@ final class IncludeInterceptor
         return $this->fp;
     }
 
+    /**
+     * @psalm-suppress InvalidPropertyAssignmentValue
+     */
     public function stream_close()
     {
         assert(is_resource($this->fp));


### PR DESCRIPTION
There's a problem with Psalm's InvalidPropertyAssignmentValue:

```
ERROR: InvalidPropertyAssignmentValue - src/IncludeInterceptor.php:229:23 - $this->fp with declared type 'bool|resource' cannot be assigned type 'closed-resource' (see https://psalm.dev/145)
        return fclose($this->fp);
```

The canonical way to fix this issue is to [use a special closed-resource type](https://github.com/vimeo/psalm/issues/2763), but it upsets Phan. Therefore we ignore this issue here.